### PR TITLE
Run as nobody user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,7 @@ FROM gcr.io/distroless/static-debian11
 ARG TARGETARCH
 ARG VERSION
 
+USER nobody
+
 ADD --chmod=777 https://dl.k8s.io/release/${VERSION}/bin/linux/${TARGETARCH}/kubectl /usr/local/bin/kubectl
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # containerized kubectl
 
-Kubernetes kubectl containerized with multi-arch support for `linux/amd64` and `linux/arm64`.
+Kubernetes kubectl containerized with multi-arch support for `linux/amd64` and `linux/arm64` running as nobody.
 
 Image available at: `ghcr.io/polarsignals/kubectl:v1.24.0`


### PR DESCRIPTION
Pretty sure the kubectl in the container is fine to run as `nobody` user. 

In fact, it's currently blocked from running by AppArmor on our GKE cluster. 
https://kubernetes.io/docs/tutorials/security/apparmor/