### PR TITLE
Set nobody user id explicitly as number

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM gcr.io/distroless/static-debian11
 ARG TARGETARCH
 ARG VERSION
 
-USER nobody
+USER 65533
 
 ADD --chmod=777 https://dl.k8s.io/release/${VERSION}/bin/linux/${TARGETARCH}/kubectl /usr/local/bin/kubectl
 


### PR DESCRIPTION
```
container has runAsNonRoot and image has non-numeric user (nobody), cannot verify user is non-root
```
Thus setting the user ID explicitly to 65533.